### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ notify 0 {
         action "service piaportforwarding stop";
 };
 ```
-
+-Restart devd to properly parse the new definition
+```
+service devd restart
+```
 **Note: The "ovpnc1" is a technical name of the OpenVPN interface from within the pfSense UI**</br>
 <img src="imgs/pia-iface.png"></br>
 


### PR DESCRIPTION
For whatever reason the pia-portforwarding service was not starting/stopping upon OVPN interface UP/DOWN events, only the log messages actions were processed. Restarting the devd service forced to re-load the definitions. After that service is properly starting/stopping upon VPN interface up/down events.